### PR TITLE
Add token field to API response from user creation

### DIFF
--- a/backend/src/main/kotlin/me/andrewda/handlers/UserHandler.kt
+++ b/backend/src/main/kotlin/me/andrewda/handlers/UserHandler.kt
@@ -6,6 +6,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.request.receiveOrNull
 import io.ktor.routing.*
 import me.andrewda.authentication.AuthLevel
+import me.andrewda.authentication.JwtConfig
 import me.andrewda.controllers.UserController
 import me.andrewda.models.NewUser
 import me.andrewda.utils.*
@@ -22,7 +23,8 @@ fun Route.user() {
 
             if (newUser.isValid && newUser.isFormatted) {
                 val user = UserController.create(newUser)
-                call.respond(user.getApiResponse())
+                val token = JwtConfig.makeToken(user)
+                call.respond(mapOf("user" to user.getApiResponse(), "token" to token))
             } else {
                 throw MissingFields()
             }


### PR DESCRIPTION
Now, `POST /api/users` will return data in the form
```
{
  "user": <User model>,
  "token": <auth token>,
  "success": <bool>
}
```
So the user can be logged in directly after signing up.

Closes #33.